### PR TITLE
movement_fix

### DIFF
--- a/Resources/Scripts/Tiles/wall.lua
+++ b/Resources/Scripts/Tiles/wall.lua
@@ -5,18 +5,18 @@ right = 0
 down = 1
 left = 2
 up = 3
-function wallTile:onEnter(x, y, dir) --lx/ly = player absolute floats, x/y = tile coords
+function wallTile:onEnter(x, y, lx, ly, dir) --lx/ly = player absolute floats, x/y = tile coords
     if dir == right then --left
-        player.x = x - 0.53
+        player.x = x - (player.w + 0.001)
     end
     if dir == left then --right
-        player.x = x + 1.03
+        player.x = x + 1.0001
     end
     if dir == up then --bottom
-        player.y = y + 1.03
+        player.y = y + 1.0001
     end
     if dir == down then --top
-        player.y = y - 0.53
+        player.y = y - (player.h + 0.001)
     end
 end
 


### PR DESCRIPTION
Fixes #9. Movement was previously being adjusted based on player location and absolute floats etc.
I noticed that sometimes movement was not doing that and assumed that it was because character was perfect distance, which I assumed to be movespeed, and testing confirmed. 
This could be improved by importing the player movespeed and size and calculating it dynamically for the creature, but for now this works.
Given that the player is 0.5, movespeed is 0.3 and a tile is 1x1, you can calculate perfect distance.